### PR TITLE
update bgfx

### DIFF
--- a/core/bgfx.lua
+++ b/core/bgfx.lua
@@ -40,6 +40,7 @@ local bgfxLib = {
     },
     msvc = {
         defines = "__STDC_FORMAT_MACROS",
+		flags = "/Zc:preprocessor",
     },
     windows = {
         includes = {

--- a/core/bimg.lua
+++ b/core/bimg.lua
@@ -27,7 +27,10 @@ lm:source_set "bimg" {
         flags = {
             "-Wno-class-memaccess",
         }
-    }
+    },
+	msvc = {
+		flags = "/Zc:preprocessor",
+	},
 }
 
 lm:source_set "bimg-miniz" {
@@ -55,7 +58,10 @@ lm:source_set "bimg-decode" {
     },
     sources = {
         "src/image_decode.cpp",
-    }
+    },
+    msvc = {
+        flags = "/Zc:preprocessor",
+    },
 }
 
 lm:source_set "bimg-iqa" {
@@ -93,6 +99,7 @@ lm:source_set "bimg-encode" {
             "/wd4244",
             "/wd4819",
             "/wd5056",
+			"/Zc:preprocessor",
         }
     },
     gcc = {

--- a/core/bx.lua
+++ b/core/bx.lua
@@ -19,6 +19,9 @@ lm:source_set "bx" {
             "-Wno-maybe-uninitialized",
         }
     },
+	msvc = {
+		flags = "/Zc:preprocessor",
+	},
     clang = {
         flags = "-ffast-math",
     },


### PR DESCRIPTION
msvc needs "/Zc:preprocessor" now 

```
fatal error C1189: #error:  "When using MSVC you must set /Zc:preprocessor compiler option."
```